### PR TITLE
Handle HorariosPorAula API response object

### DIFF
--- a/src/pages/Horarios/HorariosPorAula.test.tsx
+++ b/src/pages/Horarios/HorariosPorAula.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { render, waitFor } from '@testing-library/react';
+
+vi.mock('../../lib/api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('../../hooks/useAulas', () => ({
+  useAulas: () => ({
+    aulas: [{ id: 1, nombre: 'Aula 1' }],
+    loading: false,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock('../../components/Horarios/HorarioGrid', () => ({
+  default: vi.fn(() => null),
+}));
+
+import api from '../../lib/api';
+import HorariosPorAula from './HorariosPorAula';
+import HorarioGrid from '../../components/Horarios/HorarioGrid';
+
+const mockHorarioGrid = HorarioGrid as unknown as vi.Mock;
+
+describe('HorariosPorAula', () => {
+  it('fetches clases and renders HorarioGrid', async () => {
+    (api.get as any).mockResolvedValue({
+      data: {
+        clases: [
+          {
+            id: 1,
+            dia: 'Lunes',
+            hora_inicio: '08:00:00',
+            hora_fin: '09:00:00',
+            asignacion: {},
+            aula: {},
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/horarios/aula/1']}>
+        <Routes>
+          <Route path="/horarios/aula/:aulaId" element={<HorariosPorAula />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(mockHorarioGrid).toHaveBeenCalled());
+    expect(api.get).toHaveBeenCalledWith('/horarios/aula/1');
+    const lastCall = mockHorarioGrid.mock.calls.at(-1)!;
+    const map = lastCall[0].clases;
+    expect(Object.keys(map).length).toBeGreaterThan(0);
+  });
+});
+

--- a/src/pages/Horarios/HorariosPorAula.tsx
+++ b/src/pages/Horarios/HorariosPorAula.tsx
@@ -17,9 +17,9 @@ export default function HorariosPorAula() {
   useEffect(() => {
     if (aulaId) {
       api
-        .get<ClaseProgramada[]>(`/horarios/aula/${aulaId}`)
+        .get<{ clases: ClaseProgramada[] }>(`/horarios/aula/${aulaId}`)
         .then((res) => {
-          const valid = res.data.filter(
+          const valid = res.data.clases.filter(
             (c) =>
               c.hora_inicio &&
               c.hora_fin &&
@@ -27,10 +27,10 @@ export default function HorariosPorAula() {
               c.asignacion &&
               c.aula,
           );
-          if (valid.length !== res.data.length) {
+          if (valid.length !== res.data.clases.length) {
             console.warn(
               'Datos incompletos en la respuesta de horarios',
-              res.data,
+              res.data.clases,
             );
             window.alert(
               'La API devolvió datos incompletos para algunas clases. Se omitieron entradas inválidas.',


### PR DESCRIPTION
## Summary
- update HorariosPorAula to read `clases` list from API response
- add unit test for HorariosPorAula that mocks `{clases: []}` data

## Testing
- `npx vitest run >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68c4b406ded48322b25c7bea4c792fe9