### PR TITLE
Mostrar mensaje de horarios vacíos

### DIFF
--- a/src/pages/Horarios/HorariosPorAula.test.tsx
+++ b/src/pages/Horarios/HorariosPorAula.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, screen } from '@testing-library/react';
 
 vi.mock('../../lib/api', () => ({
   default: {
@@ -27,10 +27,16 @@ import HorariosPorAula from './HorariosPorAula';
 import HorarioGrid from '../../components/Horarios/HorarioGrid';
 
 const mockHorarioGrid = HorarioGrid as unknown as vi.Mock;
+const apiGetMock = api.get as unknown as vi.Mock;
+
+beforeEach(() => {
+  mockHorarioGrid.mockReset();
+  apiGetMock.mockReset();
+});
 
 describe('HorariosPorAula', () => {
   it('fetches clases and renders HorarioGrid', async () => {
-    (api.get as any).mockResolvedValue({
+    apiGetMock.mockResolvedValue({
       data: {
         clases: [
           {
@@ -58,6 +64,28 @@ describe('HorariosPorAula', () => {
     const lastCall = mockHorarioGrid.mock.calls.at(-1)!;
     const map = lastCall[0].clases;
     expect(Object.keys(map).length).toBeGreaterThan(0);
+  });
+
+  it('shows empty state when there are no clases', async () => {
+    apiGetMock.mockResolvedValue({
+      data: {
+        clases: [],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/horarios/aula/1']}>
+        <Routes>
+          <Route path="/horarios/aula/:aulaId" element={<HorariosPorAula />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const emptyMessage = await screen.findByText(
+      'No hay clases programadas para este horario.',
+    );
+    expect(emptyMessage).toBeTruthy();
+    expect(mockHorarioGrid).not.toHaveBeenCalled();
   });
 });
 

--- a/src/pages/Horarios/HorariosPorAula.tsx
+++ b/src/pages/Horarios/HorariosPorAula.tsx
@@ -153,7 +153,13 @@ export default function HorariosPorAula() {
           </div>
         </div>
         <div className="overflow-x-auto">
-          <HorarioGrid clases={clasesGrid} />
+          {clases.length === 0 ? (
+            <div className="flex items-center justify-center py-12 text-center text-gray-500">
+              No hay clases programadas para este horario.
+            </div>
+          ) : (
+            <HorarioGrid clases={clasesGrid} />
+          )}
         </div>
       </div>
     </DashboardLayout>

--- a/src/pages/Horarios/HorariosPorDocente.test.tsx
+++ b/src/pages/Horarios/HorariosPorDocente.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, screen } from '@testing-library/react';
 
 vi.mock('../../lib/api', () => ({
   default: {
@@ -27,10 +27,16 @@ import HorariosPorDocente from './HorariosPorDocente';
 import HorarioGrid from '../../components/Horarios/HorarioGrid';
 
 const mockHorarioGrid = HorarioGrid as unknown as vi.Mock;
+const apiGetMock = api.get as unknown as vi.Mock;
+
+beforeEach(() => {
+  mockHorarioGrid.mockReset();
+  apiGetMock.mockReset();
+});
 
 describe('HorariosPorDocente', () => {
   it('fetches clases and renders HorarioGrid', async () => {
-    (api.get as any).mockResolvedValue({
+    apiGetMock.mockResolvedValue({
       data: {
         clases: [
           {
@@ -59,6 +65,31 @@ describe('HorariosPorDocente', () => {
     const lastCall = mockHorarioGrid.mock.calls.at(-1)!;
     const map = lastCall[0].clases;
     expect(Object.keys(map).length).toBeGreaterThan(0);
+  });
+
+  it('shows empty state when there are no clases', async () => {
+    apiGetMock.mockResolvedValue({
+      data: {
+        clases: [],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/horarios/docente/1"]}>
+        <Routes>
+          <Route
+            path="/horarios/docente/:docenteId"
+            element={<HorariosPorDocente />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const emptyMessage = await screen.findByText(
+      'No hay clases programadas para este horario.',
+    );
+    expect(emptyMessage).toBeTruthy();
+    expect(mockHorarioGrid).not.toHaveBeenCalled();
   });
 });
 

--- a/src/pages/Horarios/HorariosPorDocente.tsx
+++ b/src/pages/Horarios/HorariosPorDocente.tsx
@@ -148,7 +148,13 @@ export default function HorariosPorDocente() {
           </div>
         </div>
         <div className="overflow-x-auto">
-          <HorarioGrid clases={clasesGrid} />
+          {clases.length === 0 ? (
+            <div className="flex items-center justify-center py-12 text-center text-gray-500">
+              No hay clases programadas para este horario.
+            </div>
+          ) : (
+            <HorarioGrid clases={clasesGrid} />
+          )}
         </div>
       </div>
     </DashboardLayout>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,28 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const rootDir = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
+  },
+  resolve: {
+    alias: {
+      react: resolve(rootDir, 'node_modules/react'),
+      'react-dom': resolve(rootDir, 'node_modules/react-dom'),
+    },
+    dedupe: ['react', 'react-dom'],
+  },
+  test: {
+    environment: 'jsdom',
+    server: {
+      deps: {
+        inline: ['react-router-dom'],
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- mostrar un aviso centrado cuando no hay clases por docente o aula
- limpiar mocks entre pruebas y cubrir el nuevo estado vacío
- ajustar la configuración de Vite/Vitest para usar una única copia de React al correr tests

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c85e84701c8322a4f254a6dc0e5d8a