### PR TITLE
feat: allow horizontal scrolling in horario grid

### DIFF
--- a/src/components/Horarios/HorarioGrid.css
+++ b/src/components/Horarios/HorarioGrid.css
@@ -1,0 +1,37 @@
+.horario-grid-scroll {
+  width: 100%;
+  max-width: 100%;
+  padding-bottom: 0.75rem;
+  box-sizing: border-box;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
+  scrollbar-color: #60a5fa #e5e7eb;
+  touch-action: pan-x;
+  overscroll-behavior-x: contain;
+  scrollbar-gutter: stable both-edges;
+}
+
+.horario-grid-scroll::-webkit-scrollbar {
+  height: 0.6rem;
+}
+
+.horario-grid-scroll::-webkit-scrollbar-track {
+  background-color: #e5e7eb;
+  border-radius: 9999px;
+}
+
+.horario-grid-scroll::-webkit-scrollbar-thumb {
+  background-color: #3b82f6;
+  border-radius: 9999px;
+  border: 2px solid #e5e7eb;
+}
+
+.horario-grid-scroll::-webkit-scrollbar-thumb:hover {
+  background-color: #2563eb;
+}
+
+@media (max-width: 768px) {
+  .horario-grid-scroll {
+    min-width: 100% !important;
+  }
+}

--- a/src/components/Horarios/HorarioGrid.test.tsx
+++ b/src/components/Horarios/HorarioGrid.test.tsx
@@ -51,6 +51,11 @@ describe('HorarioGrid', () => {
     expect(table).not.toBeNull();
     expect(table!.className).toContain('border-collapse');
 
+    const wrapper = table?.parentElement;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper!.className).toContain('horario-grid-scroll');
+    expect(wrapper!.className).toContain('overflow-auto');
+
     const firstBodyRow = container.querySelector('tbody tr');
     expect(firstBodyRow).not.toBeNull();
     expect(firstBodyRow!.className).toContain('odd:bg-white');

--- a/src/components/Horarios/HorarioGrid.tsx
+++ b/src/components/Horarios/HorarioGrid.tsx
@@ -1,4 +1,5 @@
 import { ClaseProgramada } from '../../types/ClaseProgramada';
+import './HorarioGrid.css';
 
 interface HorarioCell {
   clase: ClaseProgramada;
@@ -36,86 +37,88 @@ const getMateriaBadgeColor = (materiaId?: number) => {
 
 export default function HorarioGrid({ clases }: HorarioGridProps) {
   return (
-    <table className="min-w-full border-collapse border border-gray-200 bg-white text-sm">
-      <thead>
-        <tr className="bg-gray-100">
-          <th className="border border-gray-200 px-2 py-2 text-left font-semibold text-gray-700">
-            Hora
-          </th>
-          {days.map((d) => (
-            <th
-              key={d}
-              className="border border-gray-200 px-4 py-2 text-center font-semibold text-gray-700"
-            >
-              {d}
+    <div className="horario-grid-scroll min-w-max overflow-auto">
+      <table className="min-w-[56rem] w-full border-collapse border border-gray-200 bg-white text-sm">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="border border-gray-200 px-2 py-2 text-left font-semibold text-gray-700">
+              Hora
             </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {hours.map((hour) => (
-          <tr key={hour} className="odd:bg-white even:bg-slate-50/60">
-            <td className="border border-gray-200 px-2 py-2 text-sm font-semibold text-gray-700">
-              {formatHour(hour)}
-            </td>
-            {days.map((day) => {
-              const timeKey = `${hour.toString().padStart(2, '0')}:00:00`;
-              const key = `${day}-${timeKey}`;
-              const cell = clases[key];
-              if (cell === undefined) {
-                return <td key={day} className={baseCellClasses} />;
-              }
-              if (cell === null) {
-                return null;
-              }
+            {days.map((d) => (
+              <th
+                key={d}
+                className="border border-gray-200 px-4 py-2 text-center font-semibold text-gray-700"
+              >
+                {d}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {hours.map((hour) => (
+            <tr key={hour} className="odd:bg-white even:bg-slate-50/60">
+              <td className="border border-gray-200 px-2 py-2 text-sm font-semibold text-gray-700">
+                {formatHour(hour)}
+              </td>
+              {days.map((day) => {
+                const timeKey = `${hour.toString().padStart(2, '0')}:00:00`;
+                const key = `${day}-${timeKey}`;
+                const cell = clases[key];
+                if (cell === undefined) {
+                  return <td key={day} className={baseCellClasses} />;
+                }
+                if (cell === null) {
+                  return null;
+                }
 
-              const asignacion = cell.clase.asignacion;
-              const aula = cell.clase.aula;
+                const asignacion = cell.clase.asignacion;
+                const aula = cell.clase.aula;
 
-              if (!asignacion || !aula) {
+                if (!asignacion || !aula) {
+                  return (
+                    <td
+                      key={day}
+                      className={`${baseCellClasses} bg-slate-100 text-sm font-medium text-slate-600`}
+                      rowSpan={cell.rowSpan}
+                      title="Horario no disponible"
+                    >
+                      Horario no disponible
+                    </td>
+                  );
+                }
+
+                const materia = asignacion.materia;
+                const docente = asignacion.docente;
+                const materiaNombre = materia?.nombre ?? 'Sin materia';
+                const docenteNombre = docente?.nombre ?? 'Docente no asignado';
+                const aulaNombre = aula?.nombre ?? 'Aula no asignada';
+                const badgeColor = getMateriaBadgeColor(materia?.id);
+                const tooltipContent = `Materia: ${materiaNombre}\nDocente: ${docenteNombre}\nAula: ${aulaNombre}`;
+
                 return (
                   <td
                     key={day}
-                    className={`${baseCellClasses} bg-slate-100 text-sm font-medium text-slate-600`}
+                    className={`${baseCellClasses} bg-white`}
                     rowSpan={cell.rowSpan}
-                    title="Horario no disponible"
+                    title={tooltipContent}
                   >
-                    Horario no disponible
+                    <div className="flex flex-col items-center gap-1">
+                      <span
+                        className={`inline-flex items-center rounded-full border px-3 py-1 text-sm font-semibold ${badgeColor}`}
+                      >
+                        {materiaNombre}
+                      </span>
+                      <span className="text-xs text-gray-600">{docenteNombre}</span>
+                      <span className="text-xs text-gray-500">{aulaNombre}</span>
+                    </div>
                   </td>
                 );
-              }
-
-              const materia = asignacion.materia;
-              const docente = asignacion.docente;
-              const materiaNombre = materia?.nombre ?? 'Sin materia';
-              const docenteNombre = docente?.nombre ?? 'Docente no asignado';
-              const aulaNombre = aula?.nombre ?? 'Aula no asignada';
-              const badgeColor = getMateriaBadgeColor(materia?.id);
-              const tooltipContent = `Materia: ${materiaNombre}\nDocente: ${docenteNombre}\nAula: ${aulaNombre}`;
-
-              return (
-                <td
-                  key={day}
-                  className={`${baseCellClasses} bg-white`}
-                  rowSpan={cell.rowSpan}
-                  title={tooltipContent}
-                >
-                  <div className="flex flex-col items-center gap-1">
-                    <span
-                      className={`inline-flex items-center rounded-full border px-3 py-1 text-sm font-semibold ${badgeColor}`}
-                    >
-                      {materiaNombre}
-                    </span>
-                    <span className="text-xs text-gray-600">{docenteNombre}</span>
-                    <span className="text-xs text-gray-500">{aulaNombre}</span>
-                  </div>
-                </td>
-              );
-            })}
-          </tr>
-        ))}
-      </tbody>
-    </table>
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }
 

--- a/src/pages/Horarios/HorariosPorAula.tsx
+++ b/src/pages/Horarios/HorariosPorAula.tsx
@@ -195,15 +195,13 @@ export default function HorariosPorAula() {
             </button>
           </div>
         </div>
-        <div className="overflow-x-auto">
-          {clases.length === 0 ? (
-            <div className="flex items-center justify-center py-12 text-center text-gray-500">
-              No hay clases programadas para este horario.
-            </div>
-          ) : (
-            <HorarioGrid clases={clasesGrid} />
-          )}
-        </div>
+        {clases.length === 0 ? (
+          <div className="flex items-center justify-center py-12 text-center text-gray-500">
+            No hay clases programadas para este horario.
+          </div>
+        ) : (
+          <HorarioGrid clases={clasesGrid} />
+        )}
       </div>
     </DashboardLayout>
   );

--- a/src/pages/Horarios/HorariosPorDocente.tsx
+++ b/src/pages/Horarios/HorariosPorDocente.tsx
@@ -190,15 +190,13 @@ export default function HorariosPorDocente() {
             </button>
           </div>
         </div>
-        <div className="overflow-x-auto">
-          {clases.length === 0 ? (
-            <div className="flex items-center justify-center py-12 text-center text-gray-500">
-              No hay clases programadas para este horario.
-            </div>
-          ) : (
-            <HorarioGrid clases={clasesGrid} />
-          )}
-        </div>
+        {clases.length === 0 ? (
+          <div className="flex items-center justify-center py-12 text-center text-gray-500">
+            No hay clases programadas para este horario.
+          </div>
+        ) : (
+          <HorarioGrid clases={clasesGrid} />
+        )}
       </div>
     </DashboardLayout>
   );


### PR DESCRIPTION
## Summary
- wrap the HorarioGrid table in a scrollable container with tailored scrollbar styling
- add a dedicated stylesheet to enhance touch scrolling and keep the grid width consistent
- drop redundant overflow wrappers in docente/aula pages and update the grid test to cover the new container

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68c8673b7c6c83229611b5eadcd65256