### PR TITLE
Fix crash when opening schedule creation form

### DIFF
--- a/src/pages/Horarios/ClaseProgramadaForm.tsx
+++ b/src/pages/Horarios/ClaseProgramadaForm.tsx
@@ -25,6 +25,7 @@ export default function ClaseProgramadaForm() {
   const navigate = useNavigate();
   const isEdit = Boolean(id);
 
+  const [docenteId, setDocenteId] = useState('');
   const { docentes } = useDocentes();
   const { materias } = useMaterias();
   const { aulas } = useAulas();
@@ -33,8 +34,6 @@ export default function ClaseProgramadaForm() {
     useDisponibilidadDocente(docenteId);
 
   const dias = ['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];
-
-  const [docenteId, setDocenteId] = useState('');
   const [bloques, setBloques] = useState<FormState[]>([
     {
       materia_id: '',


### PR DESCRIPTION
## Summary
- ensure the schedule form initializes the docenteId state before loading the availability hook so the page renders correctly

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68c86c6719408322ae0678e5f4033396