### PR TITLE
Fix schedule form time pickers

### DIFF
--- a/src/hooks/useDisponibilidadDocente.ts
+++ b/src/hooks/useDisponibilidadDocente.ts
@@ -4,28 +4,41 @@ import { DisponibilidadDocente } from '../types/DisponibilidadDocente';
 
 export const useDisponibilidadDocente = (docenteId: string | null) => {
   const [disponibilidad, setDisponibilidad] = useState<DisponibilidadDocente[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
+    let isMounted = true;
+
     if (!docenteId) {
       setDisponibilidad([]);
-      return;
+      setLoading(false);
+      return () => {
+        isMounted = false;
+      };
     }
 
     const fetchDisponibilidad = async () => {
       try {
         setLoading(true);
         const res = await api.get(`/disponibilidad/docente/${docenteId}`);
+        if (!isMounted) return;
         setDisponibilidad(res.data.disponibles || []);
       } catch (err) {
+        if (!isMounted) return;
         console.error('Error al cargar disponibilidad:', err);
         setDisponibilidad([]);
       } finally {
-        setLoading(false);
+        if (isMounted) {
+          setLoading(false);
+        }
       }
     };
 
     fetchDisponibilidad();
+
+    return () => {
+      isMounted = false;
+    };
   }, [docenteId]);
 
   return { disponibilidad, loading };

--- a/src/pages/Horarios/ClaseProgramadaForm.tsx
+++ b/src/pages/Horarios/ClaseProgramadaForm.tsx
@@ -10,6 +10,62 @@ import { useDisponibilidadDocente } from '../../hooks/useDisponibilidadDocente';
 import { ClaseProgramada } from '../../types/ClaseProgramada';
 import { checkBlockConflicts, FormState } from './checkBlockConflicts';
 
+const DEFAULT_TIME_RANGE_START = '07:00';
+const DEFAULT_TIME_RANGE_END = '21:30';
+
+const normalizeDay = (value: string) =>
+  value
+    ? value
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+    : '';
+
+const parseTimeToMinutes = (time: string): number | null => {
+  const match = time.match(/(\d{1,2}):(\d{1,2})/);
+  if (!match) return null;
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (
+    Number.isNaN(hours) ||
+    Number.isNaN(minutes) ||
+    hours < 0 ||
+    hours > 23 ||
+    minutes < 0 ||
+    minutes > 59
+  ) {
+    return null;
+  }
+  return hours * 60 + minutes;
+};
+
+const generarHoras = (inicio: string, fin: string) => {
+  const times: string[] = [];
+  const start = parseTimeToMinutes(inicio);
+  const end = parseTimeToMinutes(fin);
+  if (start === null || end === null || start > end) {
+    return times;
+  }
+  for (let current = start; current <= end; current += 30) {
+    const hours = Math.floor(current / 60)
+      .toString()
+      .padStart(2, '0');
+    const minutes = (current % 60).toString().padStart(2, '0');
+    times.push(`${hours}:${minutes}`);
+  }
+  return times;
+};
+
+const DEFAULT_TIME_SLOTS = generarHoras(
+  DEFAULT_TIME_RANGE_START,
+  DEFAULT_TIME_RANGE_END
+);
+const DEFAULT_START_TIMES = DEFAULT_TIME_SLOTS.slice(0, -1);
+const DEFAULT_END_TIMES = DEFAULT_TIME_SLOTS.slice(1);
+
+const sortTimes = (times: string[]) =>
+  [...times].sort((a, b) => a.localeCompare(b));
+
 function toAmPm(time: string): string {
   const [hourStr, minuteStr] = time.split(':');
   let hour = parseInt(hourStr, 10);
@@ -25,16 +81,15 @@ export default function ClaseProgramadaForm() {
   const navigate = useNavigate();
   const isEdit = Boolean(id);
 
+  const [docenteId, setDocenteId] = useState('');
   const { docentes } = useDocentes();
   const { materias } = useMaterias();
   const { aulas } = useAulas();
   const { showSuccess, showError } = useToast();
-  const { disponibilidad: disponibilidadDocente } =
-    useDisponibilidadDocente(docenteId);
+  const { disponibilidad: disponibilidadDocente, loading: disponibilidadLoading } =
+    useDisponibilidadDocente(docenteId || null);
 
   const dias = ['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];
-
-  const [docenteId, setDocenteId] = useState('');
   const [bloques, setBloques] = useState<FormState[]>([
     {
       materia_id: '',
@@ -45,42 +100,24 @@ export default function ClaseProgramadaForm() {
     },
   ]);
 
-  const generarHoras = (inicio: string, fin: string) => {
-    const times: string[] = [];
-    const [sh, sm] = inicio.split(':').map(Number);
-    const [eh, em] = fin.split(':').map(Number);
-    let start = sh * 60 + sm;
-    const end = eh * 60 + em;
-    for (; start <= end; start += 30) {
-      const h = Math.floor(start / 60)
-        .toString()
-        .padStart(2, '0');
-      const m = (start % 60).toString().padStart(2, '0');
-      times.push(`${h}:${m}`);
-    }
-    return times;
-  };
-
   const obtenerHorasInicio = (dia: string) => {
+    if (!dia) return [];
+    const normalizedSelectedDay = normalizeDay(dia);
     return disponibilidadDocente
-      .filter((d) => d.dia.toLowerCase() === dia.toLowerCase())
+      .filter((d) => normalizeDay(d.dia) === normalizedSelectedDay)
       .flatMap((d) =>
-        generarHoras(
-          d.hora_inicio.slice(0, 5),
-          d.hora_fin.slice(0, 5)
-        ).slice(0, -1)
+        generarHoras(d.hora_inicio.slice(0, 5), d.hora_fin.slice(0, 5)).slice(0, -1)
       );
   };
 
   const obtenerHorasFin = (dia: string, horaInicio: string) => {
+    if (!dia || !horaInicio) return [];
+    const normalizedSelectedDay = normalizeDay(dia);
     const bloque = disponibilidadDocente.find((d) => {
+      if (normalizeDay(d.dia) !== normalizedSelectedDay) return false;
       const inicio = d.hora_inicio.slice(0, 5);
       const fin = d.hora_fin.slice(0, 5);
-      return (
-        d.dia.toLowerCase() === dia.toLowerCase() &&
-        horaInicio >= inicio &&
-        horaInicio < fin
-      );
+      return horaInicio >= inicio && horaInicio < fin;
     });
     if (!bloque) return [];
     return generarHoras(horaInicio, bloque.hora_fin.slice(0, 5)).slice(1);
@@ -245,130 +282,162 @@ export default function ClaseProgramadaForm() {
           {bloques.map((bloque, index) => {
             let horasInicio = obtenerHorasInicio(bloque.dia);
             let horasFin = obtenerHorasFin(bloque.dia, bloque.hora_inicio);
+
+            const shouldUseFallback = Boolean(
+              docenteId &&
+                bloque.dia &&
+                !disponibilidadLoading &&
+                disponibilidadDocente.length === 0
+            );
+
+            if (!horasInicio.length && shouldUseFallback) {
+              horasInicio = [...DEFAULT_START_TIMES];
+            }
+
+            if (!horasFin.length && shouldUseFallback) {
+              const startBoundary = bloque.hora_inicio;
+              horasFin = startBoundary
+                ? DEFAULT_END_TIMES.filter((hora) => hora > startBoundary)
+                : [...DEFAULT_END_TIMES];
+            }
+
             if (bloque.hora_inicio && !horasInicio.includes(bloque.hora_inicio)) {
-              horasInicio = [...horasInicio, bloque.hora_inicio];
+              horasInicio = sortTimes([...horasInicio, bloque.hora_inicio]);
+            } else {
+              horasInicio = sortTimes(horasInicio);
             }
+
             if (bloque.hora_fin && !horasFin.includes(bloque.hora_fin)) {
-              horasFin = [...horasFin, bloque.hora_fin];
+              horasFin = sortTimes([...horasFin, bloque.hora_fin]);
+            } else {
+              horasFin = sortTimes(horasFin);
             }
+
             return (
-            <div key={index} className="bg-gray-50 p-4 rounded-lg shadow space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700">
-                  Materia
-                </label>
-                <select
-                  value={bloque.materia_id}
-                  onChange={(e) =>
-                    actualizarBloque(index, 'materia_id', e.target.value)
-                  }
-                  className="w-full mt-1 px-4 py-2 border rounded-lg"
-                  required
-                >
-                  <option value="">Selecciona una materia</option>
-                  {materias.map((m) => (
-                    <option key={m.id} value={m.id}>
-                      {m.nombre}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700">
-                  Aula
-                </label>
-                <select
-                  value={bloque.aula_id}
-                  onChange={(e) =>
-                    actualizarBloque(index, 'aula_id', e.target.value)
-                  }
-                  className="w-full mt-1 px-4 py-2 border rounded-lg"
-                  required
-                >
-                  <option value="">Selecciona un aula</option>
-                  {aulas.map((a) => (
-                    <option key={a.id} value={a.id}>
-                      {a.nombre}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700">
-                  Día
-                </label>
-                <select
-                  value={bloque.dia}
-                  onChange={(e) =>
-                    actualizarBloque(index, 'dia', e.target.value)
-                  }
-                  className="w-full mt-1 px-4 py-2 border rounded-lg"
-                  required
-                >
-                  <option value="">Selecciona un día</option>
-                  {dias.map((dia) => (
-                    <option key={dia} value={dia}>
-                      {dia}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              <div className="flex gap-4">
-                <div className="flex-1">
+              <div key={index} className="bg-gray-50 p-4 rounded-lg shadow space-y-4">
+                <div>
                   <label className="block text-sm font-medium text-gray-700">
-                    Hora inicio
+                    Materia
                   </label>
                   <select
-                    value={bloque.hora_inicio}
+                    value={bloque.materia_id}
                     onChange={(e) =>
-                      actualizarBloque(index, 'hora_inicio', e.target.value)
+                      actualizarBloque(index, 'materia_id', e.target.value)
                     }
                     className="w-full mt-1 px-4 py-2 border rounded-lg"
                     required
                   >
-                    <option value="">Selecciona una hora</option>
-                    {horasInicio.map((h) => (
-                      <option key={h} value={h}>
-                        {h}
+                    <option value="">Selecciona una materia</option>
+                    {materias.map((m) => (
+                      <option key={m.id} value={m.id}>
+                        {m.nombre}
                       </option>
                     ))}
                   </select>
                 </div>
-                <div className="flex-1">
+
+                <div>
                   <label className="block text-sm font-medium text-gray-700">
-                    Hora fin
+                    Aula
                   </label>
                   <select
-                    value={bloque.hora_fin}
+                    value={bloque.aula_id}
                     onChange={(e) =>
-                      actualizarBloque(index, 'hora_fin', e.target.value)
+                      actualizarBloque(index, 'aula_id', e.target.value)
                     }
                     className="w-full mt-1 px-4 py-2 border rounded-lg"
                     required
                   >
-                    <option value="">Selecciona una hora</option>
-                    {horasFin.map((h) => (
-                      <option key={h} value={h}>
-                        {h}
+                    <option value="">Selecciona un aula</option>
+                    {aulas.map((a) => (
+                      <option key={a.id} value={a.id}>
+                        {a.nombre}
                       </option>
                     ))}
                   </select>
                 </div>
-              </div>
 
-              {!isEdit && bloques.length > 1 && (
-                <button
-                  type="button"
-                  className="text-red-600 text-sm"
-                  onClick={() => eliminarBloque(index)}
-                >
-                  Eliminar bloque
-                </button>
-              )}
-            </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700">
+                    Día
+                  </label>
+                  <select
+                    value={bloque.dia}
+                    onChange={(e) =>
+                      actualizarBloque(index, 'dia', e.target.value)
+                    }
+                    className="w-full mt-1 px-4 py-2 border rounded-lg"
+                    required
+                  >
+                    <option value="">Selecciona un día</option>
+                    {dias.map((dia) => (
+                      <option key={dia} value={dia}>
+                        {dia}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="flex gap-4">
+                  <div className="flex-1">
+                    <label className="block text-sm font-medium text-gray-700">
+                      Hora inicio
+                    </label>
+                    <select
+                      value={bloque.hora_inicio}
+                      onChange={(e) =>
+                        actualizarBloque(index, 'hora_inicio', e.target.value)
+                      }
+                      className="w-full mt-1 px-4 py-2 border rounded-lg"
+                      required
+                    >
+                      <option value="">Selecciona una hora</option>
+                      {horasInicio.map((h) => (
+                        <option key={h} value={h}>
+                          {h}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="flex-1">
+                    <label className="block text-sm font-medium text-gray-700">
+                      Hora fin
+                    </label>
+                    <select
+                      value={bloque.hora_fin}
+                      onChange={(e) =>
+                        actualizarBloque(index, 'hora_fin', e.target.value)
+                      }
+                      className="w-full mt-1 px-4 py-2 border rounded-lg"
+                      required
+                    >
+                      <option value="">Selecciona una hora</option>
+                      {horasFin.map((h) => (
+                        <option key={h} value={h}>
+                          {h}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+
+                {shouldUseFallback && (
+                  <p className="text-xs text-gray-500">
+                    El docente no tiene disponibilidad registrada; se muestran todos los
+                    horarios posibles.
+                  </p>
+                )}
+
+                {!isEdit && bloques.length > 1 && (
+                  <button
+                    type="button"
+                    className="text-red-600 text-sm"
+                    onClick={() => eliminarBloque(index)}
+                  >
+                    Eliminar bloque
+                  </button>
+                )}
+              </div>
             );
           })}
 


### PR DESCRIPTION
## Summary
- normalize day labels and harden time generation so availability slots render even if the API sends accented or irregular values
- show a graceful fallback list of 30-minute time options (with helper text) when a docente has no disponibilidad so the start/end selectors are never empty
- update the disponibilidad hook to manage loading state when no docente is selected and to avoid stale updates while switching docentes

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68c86c6719408322ae0678e5f4033396