### PR TITLE
Restringe selectores de horarios a disponibilidad docente

### DIFF
--- a/src/hooks/useDisponibilidadDocente.ts
+++ b/src/hooks/useDisponibilidadDocente.ts
@@ -22,7 +22,10 @@ export const useDisponibilidadDocente = (docenteId: string | null) => {
         setLoading(true);
         const res = await api.get(`/disponibilidad/docente/${docenteId}`);
         if (!isMounted) return;
-        setDisponibilidad(res.data.disponibles || []);
+        const data = Array.isArray(res.data)
+          ? res.data
+          : res.data?.disponibles || [];
+        setDisponibilidad(data);
       } catch (err) {
         if (!isMounted) return;
         console.error('Error al cargar disponibilidad:', err);


### PR DESCRIPTION
## Summary
- ajusta el hook de disponibilidad para aceptar respuestas en arreglo u objeto
- limita las opciones de inicio y fin a los bloques de disponibilidad del docente y reinicia la selección al cambiar
- deshabilita los selectores y muestra un aviso cuando no hay disponibilidad para el día elegido

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c87659c6e08322bffc48f743ae6762