### PR TITLE
Fix overlapping class detection

### DIFF
--- a/src/pages/Horarios/checkBlockConflicts.ts
+++ b/src/pages/Horarios/checkBlockConflicts.ts
@@ -73,7 +73,10 @@ export async function checkBlockConflicts(
     if (!Number.isNaN(materiaId)) {
       const materiaConflict = aulaClases.find((c) => {
         if (editingId && c.id === editingId) return false;
-        return c.asignacion?.materia?.id === materiaId;
+        return (
+          c.asignacion?.materia?.id === materiaId &&
+          !(bloque.hora_fin <= c.hora_inicio || bloque.hora_inicio >= c.hora_fin)
+        );
       });
       if (materiaConflict) {
         return DUPLICATE_CLASS_MESSAGE;


### PR DESCRIPTION
## Summary
- ensure duplicate class conflicts only trigger when the schedules overlap in time

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68c8889cc3f08322b27565264b137461