### PR TITLE
Handle base64url JWT payload decoding in auth store

### DIFF
--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -15,9 +15,25 @@ interface AuthState {
 let logoutTimer: number | undefined;
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
 
+function decodeBase64Url(input: string): string | null {
+  try {
+    const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
+    const paddingNeeded = (4 - (normalized.length % 4)) % 4;
+    const padded = normalized + '='.repeat(paddingNeeded);
+    return atob(padded);
+  } catch {
+    return null;
+  }
+}
+
 function parseJwt(token: string): any {
   try {
-    return JSON.parse(atob(token.split('.')[1]));
+    const [, payloadPart] = token.split('.');
+    if (!payloadPart) {
+      return null;
+    }
+    const decoded = decodeBase64Url(payloadPart);
+    return decoded ? JSON.parse(decoded) : null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- normalize JWT payload decoding to support base64url tokens before parsing

## Testing
- `npm run build` *(fails: Rollup failed to resolve import "react-apexcharts" from src/components/charts/PopularTimesChart.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a17d349c8322bb04a772f5f7e18f