### PR TITLE
Normalize extracted roles from JWT claims

### DIFF
--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -15,12 +15,73 @@ interface AuthState {
 let logoutTimer: number | undefined;
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
 
-function parseJwt(token: string): any {
+function decodeBase64Url(input: string): string | null {
   try {
-    return JSON.parse(atob(token.split('.')[1]));
+    const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
+    const paddingNeeded = (4 - (normalized.length % 4)) % 4;
+    const padded = normalized + '='.repeat(paddingNeeded);
+    return atob(padded);
   } catch {
     return null;
   }
+}
+
+function parseJwt(token: string): any {
+  try {
+    const [, payloadPart] = token.split('.');
+    if (!payloadPart) {
+      return null;
+    }
+    const decoded = decodeBase64Url(payloadPart);
+    return decoded ? JSON.parse(decoded) : null;
+  } catch {
+    return null;
+  }
+}
+
+const rolePrefixRegex = /^(?:role|roles|scope|scopes|permission|permissions|authority|authorities)[\s:/_-]*/i;
+
+function normalizeRoleValue(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const lower = trimmed.toLowerCase();
+  const withoutPrefix = lower.replace(rolePrefixRegex, '');
+  const normalized = withoutPrefix.trim() || lower;
+
+  return normalized || null;
+}
+
+function collectRolesFromValue(value: unknown): string[] {
+  if (value == null) {
+    return [];
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split(/[\s,]+/)
+      .map(normalizeRoleValue)
+      .filter((role): role is string => !!role);
+  }
+
+  if (typeof value === 'number') {
+    const normalized = normalizeRoleValue(String(value));
+    return normalized ? [normalized] : [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => collectRolesFromValue(item));
+  }
+
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const potentialKeys = ['name', 'role', 'authority', 'value', 'permission', 'code', 'id'];
+    return potentialKeys.flatMap((key) => collectRolesFromValue(record[key]));
+  }
+
+  return [];
 }
 
 function extractRoles(payload: any): string[] {
@@ -29,22 +90,18 @@ function extractRoles(payload: any): string[] {
   }
 
   const candidate =
-    payload.roles ?? payload.role ?? payload.scopes ?? payload.scope ?? payload.permissions;
+    payload.roles ??
+    payload.role ??
+    payload.scopes ??
+    payload.scope ??
+    payload.permissions ??
+    payload.authorities;
 
-  if (Array.isArray(candidate)) {
-    return candidate
-      .map((role) => (typeof role === 'string' ? role : String(role)))
-      .filter((role) => role.trim().length > 0);
-  }
+  const roles = Array.isArray(candidate)
+    ? candidate.flatMap((item) => collectRolesFromValue(item))
+    : collectRolesFromValue(candidate);
 
-  if (typeof candidate === 'string') {
-    return candidate
-      .split(/[\s,]+/)
-      .map((role) => role.trim())
-      .filter((role) => role.length > 0);
-  }
-
-  return [];
+  return Array.from(new Set(roles));
 }
 
 function scheduleLogout(expiresAt: number, logout: () => void) {


### PR DESCRIPTION
## Summary
- normalize JWT payload decoding to support base64url tokens before parsing
- canonicalize roles extracted from JWT claims so admin-only routes keep working when tokens use prefixed names (e.g. ROLE_ADMIN)

## Testing
- `node node_modules/vite/bin/vite.js build`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c8a17d349c8322bb04a772f5f7e18f