### PR TITLE
Handle horario responses with or without clases wrapper

### DIFF
--- a/src/pages/Horarios/ClaseProgramadaForm.test.ts
+++ b/src/pages/Horarios/ClaseProgramadaForm.test.ts
@@ -6,7 +6,7 @@ vi.mock('../../lib/api', () => ({
   },
 }));
 
-import { checkBlockConflicts } from './checkBlockConflicts';
+import { checkBlockConflicts, DUPLICATE_CLASS_MESSAGE } from './checkBlockConflicts';
 import api from '../../lib/api';
 
 afterEach(() => {
@@ -22,31 +22,89 @@ describe('checkBlockConflicts', () => {
     hora_fin: '09:00',
   } as any;
 
-  it('detecta conflicto de docente', async () => {
+  const createClase = () => ({
+    id: 2,
+    dia: 'Lunes',
+    hora_inicio: '08:30',
+    hora_fin: '09:30',
+    asignacion: {
+      id: 10,
+      docente: {
+        id: 20,
+        nombre: 'Docente Demo',
+        correo: 'docente@uni.edu',
+        numero_empleado: '123',
+        facultad_id: 1,
+      },
+      materia: {
+        id: 1,
+        nombre: 'Materia 1',
+        codigo: 'MAT101',
+        tipo: 'OBLIGATORIA',
+        creditos: 6,
+        plan_estudio_id: 1,
+      },
+    },
+    aula: {
+      id: 1,
+      nombre: 'Aula 1',
+      ubicacion: 'Edificio A',
+      capacidad: 30,
+    },
+  });
+
+  it.each([
+    [
+      'un objeto con la propiedad clases',
+      () => ({ clases: [createClase()] }),
+    ],
+    [
+      'un arreglo plano de clases',
+      () => [createClase()],
+    ],
+  ])('detecta conflicto de docente cuando la API responde con %s', async (_, getDocenteResponse) => {
     vi.spyOn(api, 'get').mockImplementation((url: string) => {
       if (url.includes('/horarios/docente/')) {
-        return Promise.resolve({
-          data: {
-            clases: [
-              {
-                id: 2,
-                dia: 'Lunes',
-                hora_inicio: '08:30',
-                hora_fin: '09:30',
-              },
-            ],
-          },
-        } as any);
+        return Promise.resolve({ data: getDocenteResponse() } as any);
       }
-      return Promise.resolve({ data: { clases: [] } } as any);
+      return Promise.resolve({ data: [] } as any);
     });
 
     const msg = await checkBlockConflicts(bloque, '1', false);
     expect(msg).toContain('docente');
   });
 
-  it('no hay conflicto', async () => {
-    vi.spyOn(api, 'get').mockResolvedValue({ data: { clases: [] } } as any);
+  it('detecta conflicto de materia cuando el aula responde con un arreglo', async () => {
+    vi.spyOn(api, 'get').mockImplementation((url: string) => {
+      if (url.includes('/horarios/docente/')) {
+        return Promise.resolve({ data: [] } as any);
+      }
+      return Promise.resolve({ data: [createClase()] } as any);
+    });
+
+    const msg = await checkBlockConflicts(bloque, '1', false);
+    expect(msg).toBe(DUPLICATE_CLASS_MESSAGE);
+  });
+
+  it.each([
+    [
+      'objetos vacíos',
+      () => ({ clases: [] }),
+      () => ({ clases: [] }),
+    ],
+    [
+      'arreglos vacíos',
+      () => [],
+      () => [],
+    ],
+  ])('no hay conflicto cuando la API responde con %s', async (_, getDocenteResponse, getAulaResponse) => {
+    vi.spyOn(api, 'get').mockImplementation((url: string) => {
+      if (url.includes('/horarios/docente/')) {
+        return Promise.resolve({ data: getDocenteResponse() } as any);
+      }
+      return Promise.resolve({ data: getAulaResponse() } as any);
+    });
+
     const msg = await checkBlockConflicts(bloque, '1', false);
     expect(msg).toBeNull();
   });

--- a/src/pages/Horarios/HorariosNormalization.integration.test.tsx
+++ b/src/pages/Horarios/HorariosNormalization.integration.test.tsx
@@ -122,7 +122,7 @@ describe('Horario normalization integration', () => {
 
   it('shows aula class when day and time need normalization', async () => {
     apiGetMock.mockResolvedValueOnce({
-      data: { clases: [createClase({ dia: '2' })] },
+      data: [createClase({ dia: '2' })],
     });
 
     mockUseParams.mockReturnValue({ aulaId: '1' });

--- a/src/pages/Horarios/HorariosPorAula.test.tsx
+++ b/src/pages/Horarios/HorariosPorAula.test.tsx
@@ -49,20 +49,27 @@ beforeEach(() => {
 });
 
 describe('HorariosPorAula', () => {
-  it('fetches clases and renders HorarioGrid', async () => {
+  const createClase = () => ({
+    id: 1,
+    dia: 'Lunes',
+    hora_inicio: '08:00:00',
+    hora_fin: '09:00:00',
+    asignacion: {},
+    aula: {},
+  });
+
+  it.each([
+    [
+      'un objeto con la propiedad clases',
+      () => ({ clases: [createClase()] }),
+    ],
+    [
+      'un arreglo plano de clases',
+      () => [createClase()],
+    ],
+  ])('fetches clases and renders HorarioGrid cuando la API responde con %s', async (_, getResponse) => {
     apiGetMock.mockResolvedValue({
-      data: {
-        clases: [
-          {
-            id: 1,
-            dia: 'Lunes',
-            hora_inicio: '08:00:00',
-            hora_fin: '09:00:00',
-            asignacion: {},
-            aula: {},
-          },
-        ],
-      },
+      data: getResponse(),
     });
 
     render(<HorariosPorAula />);

--- a/src/pages/Horarios/HorariosPorAula.tsx
+++ b/src/pages/Horarios/HorariosPorAula.tsx
@@ -5,6 +5,10 @@ import api from '../../lib/api';
 import { ClaseProgramada } from '../../types/ClaseProgramada';
 import { useAulas } from '../../hooks/useAulas';
 import HorarioGrid from '../../components/Horarios/HorarioGrid';
+import {
+  ClasesApiResponse,
+  normalizeClasesResponse,
+} from './normalizeClasesResponse';
 
 const BackArrowIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
@@ -99,9 +103,10 @@ export default function HorariosPorAula() {
   useEffect(() => {
     if (aulaId) {
       api
-        .get<{ clases: ClaseProgramada[] }>(`/horarios/aula/${aulaId}`)
+        .get<ClasesApiResponse>(`/horarios/aula/${aulaId}`)
         .then((res) => {
-          const valid = res.data.clases.filter(
+          const clasesResponse = normalizeClasesResponse(res.data);
+          const valid = clasesResponse.filter(
             (c) =>
               c.hora_inicio &&
               c.hora_fin &&
@@ -109,10 +114,10 @@ export default function HorariosPorAula() {
               c.asignacion &&
               c.aula,
           );
-          if (valid.length !== res.data.clases.length) {
+          if (valid.length !== clasesResponse.length) {
             console.warn(
               'Datos incompletos en la respuesta de horarios',
-              res.data.clases,
+              clasesResponse,
             );
             window.alert(
               'La API devolvió datos incompletos para algunas clases. Se omitieron entradas inválidas.',

--- a/src/pages/Horarios/HorariosPorDocente.test.tsx
+++ b/src/pages/Horarios/HorariosPorDocente.test.tsx
@@ -49,18 +49,25 @@ beforeEach(() => {
 });
 
 describe('HorariosPorDocente', () => {
-  it('fetches clases and renders HorarioGrid', async () => {
+  const createClase = () => ({
+    id: 1,
+    dia: 'Lunes',
+    hora_inicio: '08:00:00',
+    hora_fin: '09:00:00',
+  });
+
+  it.each([
+    [
+      'un objeto con la propiedad clases',
+      () => ({ clases: [createClase()] }),
+    ],
+    [
+      'un arreglo plano de clases',
+      () => [createClase()],
+    ],
+  ])('fetches clases and renders HorarioGrid cuando la API responde con %s', async (_, getResponse) => {
     apiGetMock.mockResolvedValue({
-      data: {
-        clases: [
-          {
-            id: 1,
-            dia: 'Lunes',
-            hora_inicio: '08:00:00',
-            hora_fin: '09:00:00',
-          },
-        ],
-      },
+      data: getResponse(),
     });
 
     render(<HorariosPorDocente />);
@@ -74,9 +81,7 @@ describe('HorariosPorDocente', () => {
 
   it('shows empty state when there are no clases', async () => {
     apiGetMock.mockResolvedValue({
-      data: {
-        clases: [],
-      },
+      data: [],
     });
 
     render(<HorariosPorDocente />);

--- a/src/pages/Horarios/HorariosPorDocente.tsx
+++ b/src/pages/Horarios/HorariosPorDocente.tsx
@@ -5,6 +5,10 @@ import api from '../../lib/api';
 import { ClaseProgramada } from '../../types/ClaseProgramada';
 import { useDocentes } from '../../hooks/useDocentes';
 import HorarioGrid from '../../components/Horarios/HorarioGrid';
+import {
+  ClasesApiResponse,
+  normalizeClasesResponse,
+} from './normalizeClasesResponse';
 
 const BackArrowIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
@@ -99,15 +103,16 @@ export default function HorariosPorDocente() {
   useEffect(() => {
     if (docenteId) {
       api
-        .get<{ clases: ClaseProgramada[] }>(`/horarios/docente/${docenteId}`)
+        .get<ClasesApiResponse>(`/horarios/docente/${docenteId}`)
         .then((res) => {
-          const valid = res.data.clases.filter(
+          const clasesResponse = normalizeClasesResponse(res.data);
+          const valid = clasesResponse.filter(
             (c) => c.hora_inicio && c.hora_fin && c.dia,
           );
-          if (valid.length !== res.data.clases.length) {
+          if (valid.length !== clasesResponse.length) {
             console.warn(
               'Datos incompletos en la respuesta de horarios',
-              res.data.clases,
+              clasesResponse,
             );
             window.alert(
               'La API devolvió datos incompletos para algunas clases. Se omitieron entradas inválidas.',

--- a/src/pages/Horarios/checkBlockConflicts.ts
+++ b/src/pages/Horarios/checkBlockConflicts.ts
@@ -1,5 +1,9 @@
 import api from '../../lib/api';
 import { ClaseProgramada } from '../../types/ClaseProgramada';
+import {
+  ClasesApiResponse,
+  normalizeClasesResponse,
+} from './normalizeClasesResponse';
 
 export const DUPLICATE_CLASS_MESSAGE =
   'Ya existe un horario para esta clase en el salón seleccionado';
@@ -31,12 +35,8 @@ export async function checkBlockConflicts(
   try {
     const editingId = isEdit && id ? Number(id) : null;
     const [docRes, aulaRes] = await Promise.all([
-      api.get<{ clases: ClaseProgramada[] }>(
-        `/horarios/docente/${docenteId}`
-      ),
-      api.get<{ clases: ClaseProgramada[] }>(
-        `/horarios/aula/${bloque.aula_id}`
-      ),
+      api.get<ClasesApiResponse>(`/horarios/docente/${docenteId}`),
+      api.get<ClasesApiResponse>(`/horarios/aula/${bloque.aula_id}`),
     ]);
 
     const hasConflict = (
@@ -66,8 +66,12 @@ export async function checkBlockConflicts(
       return null;
     };
 
-    const docenteClases: ClaseProgramada[] = docRes.data.clases;
-    const aulaClases: ClaseProgramada[] = aulaRes.data.clases;
+    const docenteClases: ClaseProgramada[] = normalizeClasesResponse(
+      docRes.data,
+    );
+    const aulaClases: ClaseProgramada[] = normalizeClasesResponse(
+      aulaRes.data,
+    );
     const materiaId = Number.parseInt(bloque.materia_id, 10);
 
     if (!Number.isNaN(materiaId)) {

--- a/src/pages/Horarios/normalizeClasesResponse.ts
+++ b/src/pages/Horarios/normalizeClasesResponse.ts
@@ -1,0 +1,24 @@
+import { ClaseProgramada } from '../../types/ClaseProgramada';
+
+export type ClasesApiResponse =
+  | ClaseProgramada[]
+  | { clases?: ClaseProgramada[] | null }
+  | null
+  | undefined;
+
+export const normalizeClasesResponse = (
+  data: unknown,
+): ClaseProgramada[] => {
+  if (Array.isArray(data)) {
+    return data as ClaseProgramada[];
+  }
+
+  if (data && typeof data === 'object') {
+    const maybeClases = (data as { clases?: unknown }).clases;
+    if (Array.isArray(maybeClases)) {
+      return maybeClases as ClaseProgramada[];
+    }
+  }
+
+  return [];
+};


### PR DESCRIPTION
## Summary
- add a shared helper that normalizes horario API responses whether they arrive as arrays or within a `clases` property
- update the docente and aula views plus the conflict checker to use the normalized data before filtering or validating
- extend the horario-related test suites to cover both response formats for rendering and conflict detection

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9a79b110c8322a34c2a5efe98bf51