### PR TITLE
Adjust dashboard access guard and login redirect

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -10,8 +10,7 @@ export default function Login() {
   const navigate = useNavigate();
 
   const login = useAuthStore((state) => state.login); // 👈 Acción de login
-  const fallbackRoute = '/horarios';
-  const adminRoute = '/dashboard';
+  const dashboardRoute = '/dashboard';
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -21,10 +20,7 @@ export default function Login() {
       const data = await loginUser({ username, password });
 
       login(data.access_token); // 👈 Usamos Zustand para guardar sesión
-      const userRoles = useAuthStore.getState().roles.map((role) => role.toLowerCase());
-      const hasAdminRole = userRoles.includes('admin');
-
-      navigate(hasAdminRole ? adminRoute : fallbackRoute);
+      navigate(dashboardRoute);
     } catch (err: any) {
       console.error(err);
       setError('Credenciales incorrectas o error del servidor.');

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -21,7 +21,7 @@ export default function PrivateRoute({
     return <Navigate to="/" replace />;
   }
 
-  if (requiredRoles && requiredRoles.length > 0) {
+  if (requiredRoles && requiredRoles.length > 0 && roles.length > 0) {
     const normalizedRoles = roles.map((role) => role.toLowerCase());
     const hasRole = requiredRoles.some((role) =>
       normalizedRoles.includes(role.toLowerCase()),


### PR DESCRIPTION
## Summary
- allow `PrivateRoute` to only enforce role checks when the user actually has roles loaded, preventing undesired redirects when claims are missing
- redirect successful logins straight to `/dashboard` so the dashboard is always reached after authentication

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cafcb940d88322ae8185f9c0b6fd0d