### PR TITLE
Handle expired sessions without refresh endpoint

### DIFF
--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import api from './api';
+import { useAuthStore } from '../stores/authStore';
+
+const originalLocation = window.location;
+const responseInterceptor = (api.interceptors.response as any).handlers[0].rejected as (
+  error: unknown,
+) => Promise<unknown>;
+
+let replaceSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  replaceSpy = vi.fn();
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: {
+      assign: vi.fn(),
+      reload: vi.fn(),
+      replace: replaceSpy,
+      href: 'http://localhost/horarios',
+      ancestorOrigins: originalLocation.ancestorOrigins,
+      origin: 'http://localhost',
+      protocol: 'http:',
+      host: 'localhost',
+      hostname: 'localhost',
+      port: '',
+      pathname: '/horarios',
+      search: '',
+      hash: '',
+      toString() {
+        return this.href;
+      },
+    } as Location,
+  });
+  localStorage.clear();
+  useAuthStore.setState({
+    token: null,
+    expires_at: null,
+    isAuthenticated: false,
+    roles: [],
+  });
+});
+
+afterEach(() => {
+  useAuthStore.getState().logout();
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: originalLocation,
+  });
+});
+
+describe('api interceptor 401 handling', () => {
+  it('clears the session and redirects to login when the user was authenticated', async () => {
+    useAuthStore.setState({
+      token: 'test-token',
+      expires_at: Date.now() + 60_000,
+      isAuthenticated: true,
+      roles: ['user'],
+    });
+
+    await expect(
+      responseInterceptor({
+        response: {
+          status: 401,
+          data: {},
+        },
+        config: {
+          method: 'get',
+          url: '/protected',
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: 'Tu sesión ha expirado. Vuelve a iniciar sesión.',
+      status: 401,
+    });
+
+    const state = useAuthStore.getState();
+    expect(state.isAuthenticated).toBe(false);
+    expect(state.token).toBeNull();
+    expect(replaceSpy).toHaveBeenCalledWith('/');
+  });
+
+  it('propagates backend errors without redirect when not authenticated', async () => {
+    (window.location as Location).pathname = '/';
+
+    await expect(
+      responseInterceptor({
+        response: {
+          status: 401,
+          data: { message: 'Credenciales inválidas' },
+        },
+        config: {
+          method: 'post',
+          url: '/auth/token',
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: 'Credenciales inválidas',
+      status: 401,
+    });
+
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+    expect(replaceSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -10,7 +10,11 @@ export default function Login() {
   const navigate = useNavigate();
 
   const login = useAuthStore((state) => state.login); // 👈 Acción de login
-  const dashboardRoute = '/dashboard';
+  const determineRedirect = () => {
+    const roles = useAuthStore.getState().roles ?? [];
+    const normalizedRoles = roles.map((role) => role.toLowerCase());
+    return normalizedRoles.includes('admin') ? '/dashboard' : '/horarios';
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -20,7 +24,7 @@ export default function Login() {
       const data = await loginUser({ username, password });
 
       login(data.access_token); // 👈 Usamos Zustand para guardar sesión
-      navigate(dashboardRoute);
+      navigate(determineRedirect());
     } catch (err: any) {
       console.error(err);
       setError('Credenciales incorrectas o error del servidor.');

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,6 +1,5 @@
 // src/stores/authStore.ts
 import { create } from 'zustand';
-import axios from 'axios';
 
 interface AuthState {
   token: string | null;
@@ -13,7 +12,6 @@ interface AuthState {
 }
 
 let logoutTimer: number | undefined;
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
 
 function decodeBase64Url(input: string): string | null {
   try {
@@ -146,18 +144,8 @@ export const useAuthStore = create<AuthState>((set, get) => {
       set({ token, expires_at: exp, isAuthenticated: true, roles });
     },
     refresh: async () => {
-      try {
-        const response = await axios.post(`${API_BASE_URL}/auth/refresh`, null, { withCredentials: true });
-        const newToken = response.data.access_token;
-        if (newToken) {
-          get().login(newToken);
-        } else {
-          throw new Error('No token returned');
-        }
-      } catch (err) {
-        get().logout();
-        throw err;
-      }
+      get().logout();
+      throw new Error('Refresh token no disponible en el cliente');
     },
     logout: () => {
       localStorage.removeItem('token');


### PR DESCRIPTION
## Summary
- remove the unused refresh call in the auth store and treat refresh attempts as logouts
- update the axios interceptor to clear the session and redirect to login when a 401 arrives from an authenticated call
- add coverage for the new 401 handling and adjust the login page to route users based on their roles

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cb1cb9484883228259bbfb8ef4cb64