### PR TITLE
Handle horario response formats

### DIFF
--- a/src/pages/Horarios/ClaseProgramadaForm.test.ts
+++ b/src/pages/Horarios/ClaseProgramadaForm.test.ts
@@ -62,6 +62,14 @@ describe('checkBlockConflicts', () => {
       'un arreglo plano de clases',
       () => [createClase()],
     ],
+    [
+      'un objeto plano de clase',
+      () => createClase(),
+    ],
+    [
+      'un diccionario indexado',
+      () => ({ '22': createClase() }),
+    ],
   ])('detecta conflicto de docente cuando la API responde con %s', async (_, getDocenteResponse) => {
     vi.spyOn(api, 'get').mockImplementation((url: string) => {
       if (url.includes('/horarios/docente/')) {
@@ -74,12 +82,25 @@ describe('checkBlockConflicts', () => {
     expect(msg).toContain('docente');
   });
 
-  it('detecta conflicto de materia cuando el aula responde con un arreglo', async () => {
+  it.each([
+    [
+      'un arreglo',
+      () => [createClase()],
+    ],
+    [
+      'un objeto plano',
+      () => createClase(),
+    ],
+    [
+      'un diccionario indexado',
+      () => ({ '22': createClase() }),
+    ],
+  ])('detecta conflicto de materia cuando el aula responde con %s', async (_, getAulaResponse) => {
     vi.spyOn(api, 'get').mockImplementation((url: string) => {
       if (url.includes('/horarios/docente/')) {
         return Promise.resolve({ data: [] } as any);
       }
-      return Promise.resolve({ data: [createClase()] } as any);
+      return Promise.resolve({ data: getAulaResponse() } as any);
     });
 
     const msg = await checkBlockConflicts(bloque, '1', false);

--- a/src/pages/Horarios/HorariosPorAula.test.tsx
+++ b/src/pages/Horarios/HorariosPorAula.test.tsx
@@ -67,6 +67,14 @@ describe('HorariosPorAula', () => {
       'un arreglo plano de clases',
       () => [createClase()],
     ],
+    [
+      'un objeto plano con una clase',
+      () => createClase(),
+    ],
+    [
+      'un diccionario indexado por identificadores',
+      () => ({ '15': createClase() }),
+    ],
   ])('fetches clases and renders HorarioGrid cuando la API responde con %s', async (_, getResponse) => {
     apiGetMock.mockResolvedValue({
       data: getResponse(),

--- a/src/pages/Horarios/HorariosPorDocente.test.tsx
+++ b/src/pages/Horarios/HorariosPorDocente.test.tsx
@@ -65,6 +65,14 @@ describe('HorariosPorDocente', () => {
       'un arreglo plano de clases',
       () => [createClase()],
     ],
+    [
+      'un objeto plano con una clase',
+      () => createClase(),
+    ],
+    [
+      'un diccionario indexado por identificadores',
+      () => ({ '10': createClase() }),
+    ],
   ])('fetches clases and renders HorarioGrid cuando la API responde con %s', async (_, getResponse) => {
     apiGetMock.mockResolvedValue({
       data: getResponse(),


### PR DESCRIPTION
## Summary
- Make the horario normalizer resilient to API responses that return classes as single objects or id-indexed maps so timetable views and exports can render again
- Extend the schedule conflict unit tests to cover the new response shapes for docentes and aulas

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb360e96e8832290d4c168993ee5b9