### PR TITLE
Handle metadata arrays when extracting clases

### DIFF
--- a/src/pages/Horarios/HorariosPorDocente.test.tsx
+++ b/src/pages/Horarios/HorariosPorDocente.test.tsx
@@ -73,6 +73,10 @@ describe('HorariosPorDocente', () => {
       'un diccionario indexado por identificadores',
       () => ({ '10': createClase() }),
     ],
+    [
+      'un arreglo que inicia con metadata antes de las clases',
+      () => [[{ total: 1 }], { clases: [createClase()] }],
+    ],
   ])('fetches clases and renders HorarioGrid cuando la API responde con %s', async (_, getResponse) => {
     apiGetMock.mockResolvedValue({
       data: getResponse(),

--- a/src/utils/horarios.ts
+++ b/src/utils/horarios.ts
@@ -154,7 +154,24 @@ const extractFirstArray = (value: unknown, visited = new WeakSet<object>()): unk
   }
 
   if (Array.isArray(value)) {
-    return value;
+    if (visited.has(value)) {
+      return [];
+    }
+    visited.add(value);
+
+    const claseValues = value.filter(isClaseRecord);
+    if (claseValues.length > 0) {
+      return claseValues;
+    }
+
+    for (const item of value) {
+      const nested = extractFirstArray(item, visited);
+      if (nested.length > 0) {
+        return nested;
+      }
+    }
+
+    return [];
   }
 
   if (!isObject(value)) {


### PR DESCRIPTION
## Summary
- continue traversing nested structures when `extractFirstArray` encounters arrays without schedule records
- add HorariosPorDocente coverage for responses that start with metadata before the clases collection

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cb42d95758832292c1f8dbaed2c3d6