### PR TITLE
Handle metadata-only horario responses

### DIFF
--- a/src/pages/Horarios/HorariosPorAula.test.tsx
+++ b/src/pages/Horarios/HorariosPorAula.test.tsx
@@ -90,6 +90,27 @@ describe('HorariosPorAula', () => {
     expect(map['Lunes-08:30:00']).toBeNull();
   });
 
+  it('ignores metadata arrays with asignaciones without schedule fields', async () => {
+    apiGetMock.mockResolvedValue({
+      data: [
+        [
+          { asignacion: { id: 20, materia: 'Meta' }, aula: { id: 1 } },
+          { aula: { id: 2, nombre: 'Meta Aula' } },
+        ],
+        { clases: [createClase()] },
+      ],
+    });
+
+    render(<HorariosPorAula />);
+
+    await waitFor(() => expect(mockHorarioGrid).toHaveBeenCalled());
+    expect(api.get).toHaveBeenCalledWith('/horarios/aula/1');
+    const lastCall = mockHorarioGrid.mock.calls.at(-1)!;
+    const map = lastCall[0].clases;
+    expect(map['Lunes-08:00:00']?.rowSpan).toBe(2);
+    expect(map['Lunes-08:30:00']).toBeNull();
+  });
+
   it('shows empty state when there are no clases', async () => {
     apiGetMock.mockResolvedValue({
       data: {

--- a/src/pages/Horarios/HorariosPorDocente.test.tsx
+++ b/src/pages/Horarios/HorariosPorDocente.test.tsx
@@ -92,6 +92,27 @@ describe('HorariosPorDocente', () => {
     expect(map['Lunes-08:30:00']).toBeNull();
   });
 
+  it('ignores metadata arrays with asignaciones without schedule fields', async () => {
+    apiGetMock.mockResolvedValue({
+      data: [
+        [
+          { asignacion: { id: 99, materia: 'Meta' } },
+          { aula: { id: 5, nombre: 'Meta Aula' } },
+        ],
+        { clases: [createClase()] },
+      ],
+    });
+
+    render(<HorariosPorDocente />);
+
+    await waitFor(() => expect(mockHorarioGrid).toHaveBeenCalled());
+    expect(api.get).toHaveBeenCalledWith('/horarios/docente/1');
+    const lastCall = mockHorarioGrid.mock.calls.at(-1)!;
+    const map = lastCall[0].clases;
+    expect(map['Lunes-08:00:00']?.rowSpan).toBe(2);
+    expect(map['Lunes-08:30:00']).toBeNull();
+  });
+
   it('shows empty state when there are no clases', async () => {
     apiGetMock.mockResolvedValue({
       data: [],

--- a/src/utils/horarios.ts
+++ b/src/utils/horarios.ts
@@ -160,7 +160,7 @@ const extractFirstArray = (value: unknown, visited = new WeakSet<object>()): unk
     visited.add(value);
 
     const claseValues = value.filter(isClaseRecord);
-    if (claseValues.length > 0) {
+    if (claseValues.some(hasScheduleFields)) {
       return claseValues;
     }
 
@@ -184,13 +184,15 @@ const extractFirstArray = (value: unknown, visited = new WeakSet<object>()): unk
   visited.add(value);
 
   if (isClaseRecord(value)) {
-    return [value];
+    if (hasScheduleFields(value)) {
+      return [value];
+    }
   }
 
   if (isNumericKeyMap(value)) {
     const numericValues = Object.values(value);
     const claseValues = numericValues.filter(isClaseRecord);
-    if (claseValues.length > 0) {
+    if (claseValues.some(hasScheduleFields)) {
       return claseValues;
     }
   }
@@ -205,7 +207,7 @@ const extractFirstArray = (value: unknown, visited = new WeakSet<object>()): unk
 
   const directValues = Object.values(value);
   const claseValues = directValues.filter(isClaseRecord);
-  if (claseValues.length > 0) {
+  if (claseValues.some(hasScheduleFields)) {
     return claseValues;
   }
 


### PR DESCRIPTION
## Summary
- update extractFirstArray to only return collections that include entries with real schedule fields
- ensure recursive search still explores classCollectionKeys, numeric maps and nested values
- add docente and aula tests that cover metadata arrays with asignacion/aula but no dia/hora fields

## Testing
- npm test -- HorariosPorDocente
- npm test -- --run src/pages/Horarios/HorariosPorDocente.test.tsx
- npm test -- HorariosPorAula
- npm test -- --run src/pages/Horarios/HorariosPorAula.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb47129d80832289583a59827e2d52