### PR TITLE
Propagate metadata from wrapper horarios responses

### DIFF
--- a/src/pages/Horarios/HorariosPorAula.test.tsx
+++ b/src/pages/Horarios/HorariosPorAula.test.tsx
@@ -90,15 +90,20 @@ describe('HorariosPorAula', () => {
     expect(map['Lunes-08:30:00']).toBeNull();
   });
 
-  it('ignores metadata arrays with asignaciones without schedule fields', async () => {
+  it('propagates metadata from wrappers with horarios en forma de diccionario', async () => {
     apiGetMock.mockResolvedValue({
-      data: [
-        [
-          { asignacion: { id: 20, materia: 'Meta' }, aula: { id: 1 } },
-          { aula: { id: 2, nombre: 'Meta Aula' } },
-        ],
-        { clases: [createClase()] },
-      ],
+      data: {
+        asignacion: { id: 20, materia: 'Meta' },
+        aula: { id: 2, nombre: 'Meta Aula' },
+        horarios: {
+          0: {
+            id: 30,
+            dia: 'Lunes',
+            hora_inicio: '08:00:00',
+            hora_fin: '09:00:00',
+          },
+        },
+      },
     });
 
     render(<HorariosPorAula />);
@@ -107,8 +112,12 @@ describe('HorariosPorAula', () => {
     expect(api.get).toHaveBeenCalledWith('/horarios/aula/1');
     const lastCall = mockHorarioGrid.mock.calls.at(-1)!;
     const map = lastCall[0].clases;
-    expect(map['Lunes-08:00:00']?.rowSpan).toBe(2);
+    const cell = map['Lunes-08:00:00'];
+    expect(cell?.rowSpan).toBe(2);
     expect(map['Lunes-08:30:00']).toBeNull();
+    expect(cell?.clase.hora_inicio).toBe('08:00:00');
+    expect(cell?.clase.asignacion).toEqual({ id: 20, materia: 'Meta' });
+    expect(cell?.clase.aula).toEqual({ id: 2, nombre: 'Meta Aula' });
   });
 
   it('shows empty state when there are no clases', async () => {

--- a/src/pages/Horarios/HorariosPorDocente.test.tsx
+++ b/src/pages/Horarios/HorariosPorDocente.test.tsx
@@ -92,15 +92,20 @@ describe('HorariosPorDocente', () => {
     expect(map['Lunes-08:30:00']).toBeNull();
   });
 
-  it('ignores metadata arrays with asignaciones without schedule fields', async () => {
+  it('propagates asignacion y aula desde envoltorios con metadata', async () => {
     apiGetMock.mockResolvedValue({
-      data: [
-        [
-          { asignacion: { id: 99, materia: 'Meta' } },
-          { aula: { id: 5, nombre: 'Meta Aula' } },
+      data: {
+        asignacion: { id: 99, materia: 'Meta' },
+        aula: { id: 5, nombre: 'Meta Aula' },
+        clases: [
+          {
+            id: 10,
+            dia: 'Lunes',
+            hora_inicio: '08:00:00',
+            hora_fin: '09:00:00',
+          },
         ],
-        { clases: [createClase()] },
-      ],
+      },
     });
 
     render(<HorariosPorDocente />);
@@ -109,8 +114,13 @@ describe('HorariosPorDocente', () => {
     expect(api.get).toHaveBeenCalledWith('/horarios/docente/1');
     const lastCall = mockHorarioGrid.mock.calls.at(-1)!;
     const map = lastCall[0].clases;
-    expect(map['Lunes-08:00:00']?.rowSpan).toBe(2);
+    const cell = map['Lunes-08:00:00'];
+    expect(cell?.rowSpan).toBe(2);
     expect(map['Lunes-08:30:00']).toBeNull();
+    expect(cell?.clase.dia).toBe('Lunes');
+    expect(cell?.clase.hora_inicio).toBe('08:00:00');
+    expect(cell?.clase.asignacion).toEqual({ id: 99, materia: 'Meta' });
+    expect(cell?.clase.aula).toEqual({ id: 5, nombre: 'Meta Aula' });
   });
 
   it('shows empty state when there are no clases', async () => {


### PR DESCRIPTION
## Summary
- merge parent asignacion/aula metadata into nested clase records when normalizing horarios responses
- keep extractFirstArray recursion over arrays, numeric maps and collections while preventing cycles
- verify HorarioGrid receives classes with merged metadata in docente and aula views

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cb741f2c4c8322a7d806887a6aca0d